### PR TITLE
Pkgconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ compile
 config.guess
 config.status
 config.sub
+config.log
 configure
 depcomp
 install-sh

--- a/configure.ac
+++ b/configure.ac
@@ -221,7 +221,7 @@ AC_MSG_RESULT([${want_png}])
 if test "x${want_png}" = "xyes" ; then
    PKG_CHECK_MODULES([PNG], [libpng],
       [have_libpng="yes"; 
-       LIBPNG_LIBADD=`pkg-config --libs libpng`;
+       LIBPNG_LIBADD=${PNG_LIBS};
        M4RI_USE_PNG_PC=libpng],
       [have_libpng="no"])
    if ! test "x${have_libpng}" = "xyes" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -220,7 +220,9 @@ AC_MSG_RESULT([${want_png}])
 
 if test "x${want_png}" = "xyes" ; then
    PKG_CHECK_MODULES([PNG], [libpng],
-      [have_libpng="yes"; LIBPNG_LIBADD=`pkg-config --libs libpng`],
+      [have_libpng="yes"; 
+       LIBPNG_LIBADD=`pkg-config --libs libpng`;
+       M4RI_USE_PNG_PC=libpng],
       [have_libpng="no"])
    if ! test "x${have_libpng}" = "xyes" ; then
       AC_CHECK_LIB([png],
@@ -239,6 +241,7 @@ if test "x${want_png}" = "xyes" ; then
                ])
             ])
         ])
+       RAW_LIBPNG=${LIBPNG_LIBADD}
    fi
    if test "x${have_libpng}" = "xno" ; then
       AC_MSG_WARN([Can not find a usuable PNG library. Make sure that CPPFLAGS and LDFLAGS are correctly set.])
@@ -249,6 +252,8 @@ if test "x${have_libpng}" = "xyes" ; then
    M4RI_HAVE_LIBPNG=1
    AC_SUBST(M4RI_HAVE_LIBPNG)
    AC_SUBST(LIBPNG_LIBADD)
+   AC_SUBST(M4RI_USE_PNG_PC)
+   AC_SUBST(RAW_LIBPNG)
 else
    M4RI_HAVE_LIBPNG=0
    AC_SUBST(M4RI_HAVE_LIBPNG)

--- a/m4ri.pc.in
+++ b/m4ri.pc.in
@@ -6,5 +6,6 @@ includedir=@includedir@
 Name: M4RI
 Description: Dense linear algebra over GF(2).
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lm4ri -lm
-Cflags: -I${includedir} @CFLAGS@ @SIMD_CFLAGS@ @OPENMP_CFLAGS@
+Requires: @M4RI_USE_PNG_PC@
+Libs: -L${libdir} -lm4ri @RAW_LIBPNG@ -lm
+Cflags: -I${includedir} @SIMD_CFLAGS@ @OPENMP_CFLAGS@


### PR DESCRIPTION
PR for issue #2. I added mechanism to incorporate libpng requirements (or lack thereof) in the .pc file. I removed the optimisation flags (but not the SIMD flags) from CFlags.
With this, m4rie and BRiAl shouldn't need to use AX_M4RI_CFLAGS if pkg-config is installed and m4ri.pc can be found.