### PR TITLE
Don't autodetect SSE2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,15 +39,12 @@ AS_IF([test "x$enable_sse2" != "xno"], [
    if test "$m4ri_wrapword" = "yes"; then
       AC_MSG_ERROR([SSE2 cannot be supported when wrapping word in a C++ class.])
    fi
-   AX_EXT()
 ])
-if test x"$ax_cv_have_sse2_ext" = x"yes"; then
-  M4RI_HAVE_SSE2=1
-else
-  M4RI_HAVE_SSE2=0
-fi
-AC_SUBST(M4RI_HAVE_SSE2)
 
+AS_IF([test "x$enable_sse2" = "xno"],
+    [M4RI_HAVE_SSE2=0],
+    [M4RI_HAVE_SSE2="(defined(__SSE2__) && __SSE2__)"])
+AC_SUBST(M4RI_HAVE_SSE2)
 
 AC_ARG_WITH(papi,
     AS_HELP_STRING([--with-papi@<:@=PATH@:>@], [The PAPI install prefix, if configure can't find it.]),

--- a/m4ri.pc.in
+++ b/m4ri.pc.in
@@ -8,4 +8,4 @@ Description: Dense linear algebra over GF(2).
 Version: @PACKAGE_VERSION@
 Requires: @M4RI_USE_PNG_PC@
 Libs: -L${libdir} -lm4ri @RAW_LIBPNG@ @LIBM@ @LIBPNG_LIBADD@
-Cflags: -I${includedir} @SIMD_FLAGS@ @OPENMP_CFLAGS@ @LIBPNG_CFLAGS@
+Cflags: -I${includedir} @OPENMP_CFLAGS@ @LIBPNG_CFLAGS@

--- a/m4ri/m4ri_config.h.in
+++ b/m4ri/m4ri_config.h.in
@@ -14,8 +14,7 @@
 #define __M4RI_HAVE_LIBPNG              @M4RI_HAVE_LIBPNG@
 
 #define __M4RI_CC                       "@CC@"
-#define __M4RI_CFLAGS                   "@SIMD_FLAGS@ @OPENMP_CFLAGS@ @CFLAGS@"
-#define __M4RI_SIMD_CFLAGS              "@SIMD_FLAGS@"
+#define __M4RI_CFLAGS                   "@OPENMP_CFLAGS@ @CFLAGS@"
 #define __M4RI_OPENMP_CFLAGS            "@OPENMP_CFLAGS@"
 
 // Helper macros.


### PR DESCRIPTION
Instead, test __SSE2__ in the compiler.

This doesn't make a difference on x86_64 as sse2 is always present.
To enable sse2 for i686, one can add `-msse2` to `CFLAGS`.

This partly addresses #9. In the current version, simd flags would be leaked
from the build box, even unused ones as avx2 and avx512.
