### PR TITLE
Use soname `libm4ri.so.1`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,7 @@ EXTRA_DIST=m4ri/Doxyfile
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = m4ri.pc
 
-libm4ri_la_LDFLAGS = -release 0.0.$(RELEASE) -no-undefined
+libm4ri_la_LDFLAGS = -version-info @LT_VERSION@ -no-undefined
 libm4ri_la_LIBADD = $(LIBPNG_LIBADD) $(LIBM)
 
 SUBDIRS = . tests

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,9 @@
 AC_INIT([m4ri],[20240729])
 
+# See http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
+LT_VERSION=1:0:0
+AC_SUBST(LT_VERSION)
+
 AC_CANONICAL_HOST
 
 AC_CONFIG_SRCDIR(m4ri/brilliantrussian.c)


### PR DESCRIPTION
Resolves #11.

See http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html for updating the version.

TL;DR where LT_VERSION=c:r:a
- increment "r" each release;
- when interfaces are only added, increment both c and a
- when interfaces are removed or changed, increment c and set a to 0

The soname will be `libm4ri.so.$((c-a))`, so only the third case will force users to rebuild.

The idea is that libm4ri.so.1.0.* is both backward and forward compatible,
libm4ri.so.1.1.* will be backward compatible but not forward compatible, and
libm4ri.so.2.* will be neither.
