### PR TITLE
Improvements to the pkg-config file

### DIFF
--- a/m4ri.pc.in
+++ b/m4ri.pc.in
@@ -6,6 +6,7 @@ includedir=@includedir@
 Name: M4RI
 Description: Dense linear algebra over GF(2).
 Version: @PACKAGE_VERSION@
-Requires: @M4RI_USE_PNG_PC@
-Libs: -L${libdir} -lm4ri @RAW_LIBPNG@ @LIBM@ @LIBPNG_LIBADD@
+Requires.private: @M4RI_USE_PNG_PC@
+Libs: -L${libdir} -lm4ri @LIBM@
+Libs.private: @RAW_LIBPNG@ @LIBPNG_LIBADD@
 Cflags: -I${includedir} @OPENMP_CFLAGS@ @LIBPNG_CFLAGS@

--- a/m4ri.pc.in
+++ b/m4ri.pc.in
@@ -8,5 +8,5 @@ Description: Dense linear algebra over GF(2).
 Version: @PACKAGE_VERSION@
 Requires.private: @M4RI_USE_PNG_PC@
 Libs: -L${libdir} -lm4ri @LIBM@
-Libs.private: @RAW_LIBPNG@ @LIBPNG_LIBADD@
-Cflags: -I${includedir} @OPENMP_CFLAGS@ @LIBPNG_CFLAGS@
+Libs.private: @OPENMP_CFLAGS@ @RAW_LIBPNG@ @LIBPNG_LIBADD@
+Cflags: -I${includedir} @LIBPNG_CFLAGS@


### PR DESCRIPTION
Two small improvements to `m4ri.pc`:

1. libpng becomes an internal (`Requires.private`) dependency. I've looked at the code, and I don't think any symbols from libpng are leaked to consumers. In other words, someone linking their program to m4ri does not need to supply `-lpng`. This change prevents the `-lpng` from being output by `pkg-config --libs m4ri`.

2. The OpenMP flags are applied to static linking only. This was my original motivation for digging into this file. My copy of sage was being compiled (but not linked!) with `-fopenmp` because that flag appears in the pkg-config output for m4ri. The result of course crashes due to missing libgomp symbols. The `OPENMP_FLAGS` are applied to linking to (only) to avoid this issue, and made private for the same reason we made libpng private.

Resolves:

* https://github.com/malb/m4ri/issues/2
* https://github.com/malb/m4ri/issues/9

CC: @kiwifb, @dimpase, @tornaria, @arojas, @isuruf