### PR TITLE
Fix overflows in `mzd_init()`

### DIFF
--- a/m4ri/mmc.h
+++ b/m4ri/mmc.h
@@ -72,6 +72,10 @@ typedef struct _mm_block {
  * \return Pointer to allocated memory block.
  */
 static inline void *m4ri_mmc_calloc(size_t count, size_t size) {
+  if (size && count > SIZE_MAX/size) {
+      m4ri_die("m4ri_mmc_calloc: overflow in multiplication\n");
+      return NULL; /* unreachable */
+  }
   size_t total_size = count * size;
   void *ret         = m4ri_mmc_malloc(total_size);
   memset((char *)ret, 0, total_size);

--- a/m4ri/mzd.c
+++ b/m4ri/mzd.c
@@ -144,13 +144,12 @@ mzd_t *mzd_init(rci_t r, rci_t c) {
   mzd_t *A = mzd_t_malloc();
   A->nrows         = r;
   A->ncols         = c;
-  A->width         = (c + m4ri_radix - 1) / m4ri_radix;
+  A->width         = c > 0 ? (c - 1) / m4ri_radix + 1 : 0;
   A->rowstride     = ((A->width & 1) == 0) ? A->width : A->width + 1;
   A->high_bitmask  = __M4RI_LEFT_BITMASK(c % m4ri_radix);
   A->flags         = (A->high_bitmask != m4ri_ffff) ? mzd_flag_nonzero_excess : 0;
   if (r && c) {
-    size_t block_words = r * A->rowstride;
-    A->data = m4ri_mmc_calloc(block_words, sizeof(word));
+    A->data = m4ri_mmc_calloc(r, sizeof(word) * A->rowstride);
   } else {
     A->data = NULL;
   }


### PR DESCRIPTION
The multiplication in `mzd_init()` causes a segfault in sagemath on 32 bit.

A doctest runs `MatrixSpace(GF(2), 2^30)(1)` expecting to get a memory allocation error, but it doesn't. In fact, the `data` member ends up with a `malloc(0)` (not `NULL`!) which later causes a segfault. All of this because (2^30) * (2^30/64) is 0 when `size_t` is 32 bits.

While looking at this I also noticed that `mzd_init(1, INT_MAX)` aborts (on any architecture), due to another overflow which I also fix here.
