### PR TITLE
fix the compiler warnings

### DIFF
--- a/m4ri/io.c
+++ b/m4ri/io.c
@@ -34,7 +34,7 @@
 #include "io.h"
 
 void mzd_info(const mzd_t *A, int do_rank) {
-  printf("nrows: %6d, ncols: %6d, density: %6.5f, hash: 0x%016zx", A->nrows, A->ncols,
+  printf("nrows: %6d, ncols: %6d, density: %6.5f, hash: 0x%016" PRIx64, A->nrows, A->ncols,
          mzd_density(A, 1), mzd_hash(A));
   if (do_rank) {
     mzd_t *AA = mzd_copy(NULL, A);

--- a/m4ri/io.c
+++ b/m4ri/io.c
@@ -238,27 +238,13 @@ int mzd_to_png_fh(const mzd_t *A, FILE *fh, int compression_level, const char *c
   char pdate[21];
   time_t ptime = time(NULL);
   struct tm ltime;
-  int have_local_time = 0;
-
 #if defined(_WIN32)
-  have_local_time = (localtime_s(&ltime, &ptime) == 0);
+  localtime_s(&ltime, &ptime);
 #else
-  {
-    struct tm *ltime_ptr = localtime(&ptime);
-    if (ltime_ptr != NULL) {
-      ltime           = *ltime_ptr;
-      have_local_time = 1;
-    }
-  }
+  ltime = *localtime(&ptime);
 #endif
-
-  if (have_local_time) {
-    if (strftime(pdate, sizeof(pdate), "%Y/%m/%d %H:%M:%S", &ltime) == 0) {
-      pdate[0] = '\0';
-    }
-  } else {
+  if (strftime(pdate, sizeof(pdate), "%Y/%m/%d %H:%M:%S", &ltime) == 0)
     pdate[0] = '\0';
-  }
 
   txt_ptr[0].key         = "Software";
   txt_ptr[0].text        = "M4RI";

--- a/m4ri/io.c
+++ b/m4ri/io.c
@@ -238,10 +238,10 @@ int mzd_to_png_fh(const mzd_t *A, FILE *fh, int compression_level, const char *c
   char pdate[21];
   time_t ptime = time(NULL);
   struct tm ltime;
-#if defined(_WIN32)
-  localtime_s(&ltime, &ptime);
+#if defined(_WIN32) && defined(_MSC_VER)
+    localtime_s(&ltime, &ptime);
 #else
-  ltime = *localtime(&ptime);
+    localtime_r(&ptime, &ltime);
 #endif
   if (strftime(pdate, sizeof(pdate), "%Y/%m/%d %H:%M:%S", &ltime) == 0)
     pdate[0] = '\0';

--- a/m4ri/io.c
+++ b/m4ri/io.c
@@ -24,6 +24,7 @@
 
 #include "m4ri_config.h"
 #include <inttypes.h>
+#include <time.h>
 
 #if __M4RI_HAVE_LIBPNG
 #include <png.h>
@@ -235,10 +236,29 @@ int mzd_to_png_fh(const mzd_t *A, FILE *fh, int compression_level, const char *c
   png_text txt_ptr[3];
 
   char pdate[21];
-  time_t ptime     = time(NULL);
-  struct tm *ltime = localtime(&ptime);
-  sprintf(pdate, "%04d/%02d/%02d %02d:%02d:%02d", ltime->tm_year + 1900, ltime->tm_mon + 1,
-          ltime->tm_mday, ltime->tm_hour, ltime->tm_min, ltime->tm_sec);
+  time_t ptime = time(NULL);
+  struct tm ltime;
+  int have_local_time = 0;
+
+#if defined(_WIN32)
+  have_local_time = (localtime_s(&ltime, &ptime) == 0);
+#else
+  {
+    struct tm *ltime_ptr = localtime(&ptime);
+    if (ltime_ptr != NULL) {
+      ltime           = *ltime_ptr;
+      have_local_time = 1;
+    }
+  }
+#endif
+
+  if (have_local_time) {
+    if (strftime(pdate, sizeof(pdate), "%Y/%m/%d %H:%M:%S", &ltime) == 0) {
+      pdate[0] = '\0';
+    }
+  } else {
+    pdate[0] = '\0';
+  }
 
   txt_ptr[0].key         = "Software";
   txt_ptr[0].text        = "M4RI";

--- a/m4ri/ple_russian.c
+++ b/m4ri/ple_russian.c
@@ -318,11 +318,9 @@ void mzd_make_table_ple(mzd_t const *A, rci_t r, rci_t writecol, int k, int knar
 #include "ple_russian_template.h"
 #undef N
 
-#if __M4RI_PLE_NTABLES >= 8
 #define N 8
 #include "ple_russian_template.h"
 #undef N
-#endif
 
 void _mzd_ple_a10(mzd_t *A, mzp_t const *P, rci_t const start_row, rci_t const start_col,
                   wi_t const addblock, int const k, rci_t *pivots) {

--- a/m4ri/ple_russian.c
+++ b/m4ri/ple_russian.c
@@ -318,9 +318,11 @@ void mzd_make_table_ple(mzd_t const *A, rci_t r, rci_t writecol, int k, int knar
 #include "ple_russian_template.h"
 #undef N
 
+#if __M4RI_PLE_NTABLES >= 8
 #define N 8
 #include "ple_russian_template.h"
 #undef N
+#endif
 
 void _mzd_ple_a10(mzd_t *A, mzp_t const *P, rci_t const start_row, rci_t const start_col,
                   wi_t const addblock, int const k, rci_t *pivots) {
@@ -530,6 +532,7 @@ rci_t _mzd_ple_russian(mzd_t *A, mzp_t *P, mzp_t *Q, int k) {
     }
 
     switch (ntables) {
+#if __M4RI_PLE_NTABLES >= 8
     case 8:
       /**
        * 5. update A1 = (A01 | A11) */
@@ -540,6 +543,7 @@ rci_t _mzd_ple_russian(mzd_t *A, mzp_t *P, mzp_t *Q, int k) {
       if (done_row < nrows)
         _mzd_process_rows_ple_8(A, done_row + 1, nrows, curr_col, k_, (const ple_table_t **)T);
       break;
+#endif
 
     case 7:
       _mzd_ple_a11_7(A, curr_row + knar, done_row + 1, curr_col, splitblock, k_,


### PR DESCRIPTION
1. Use `strftime` instead of `sprintf`
2. Guard N=8 PLE table code behind `__M4RI_PLE_NTABLES >= 8`